### PR TITLE
Added the feed for Russ Cox's blog

### DIFF
--- a/feeds.yml
+++ b/feeds.yml
@@ -143,3 +143,8 @@ rakyll:
   scrape_url: https://rakyll.org/index.xml
   url: https://rakyll.org/
   scraper: FeedScraper
+research!rsc:
+  title: Thoughts and links about programming, by Russ Cox
+  scrape_url: http://research.swtch.com/feed.atom
+  url: https://research.swtch.com
+  scraper: FeedScraper


### PR DESCRIPTION
Russ Cox is a Golang hacker.

It would be nice to have his blog included.

See:
https://swtch.com/~rsc/
https://github.com/rsc
https://hachyderm.io/@rsc#.
https://twitter.com/_rsc

Thank you