### PR TITLE
Added Jamie Tanna's go tag feed

### DIFF
--- a/feeds.yml
+++ b/feeds.yml
@@ -160,6 +160,6 @@ rednafi:
   scraper: FeedScraper
 jvt:
   title: Jamie Tanna | Software Engineer
-  scrape_url: https://www.jvt.me/tags/go/feed.xml
+  scrape_url: https://www.jvt.me/tags/go/feed.articles.xml
   url: https://www.jvt.me/tags/go/
   scraper: FeedScraper

--- a/feeds.yml
+++ b/feeds.yml
@@ -158,3 +158,8 @@ rednafi:
   scrape_url: https://rednafi.com/go/index.xml
   url: https://rednafi.com/go
   scraper: FeedScraper
+jvt:
+  title: Jamie Tanna | Software Engineer
+  scrape_url: https://www.jvt.me/tags/go/feed.xml
+  url: https://www.jvt.me/tags/go/
+  scraper: FeedScraper


### PR DESCRIPTION
On his blog he has various topics, but the Golang specific ones are tagged with `go` tag, which is nice of him.

That way only Golang relevant posts will be featured on the planet.

Here is his `go` feed, for a quick browse: https://www.jvt.me/tags/go/

/cc @jamietanna